### PR TITLE
COREX-2041 - User.com sync issue

### DIFF
--- a/src/UserCom.Client/Model/Attributes/AttributeValue.cs
+++ b/src/UserCom.Client/Model/Attributes/AttributeValue.cs
@@ -1,4 +1,5 @@
 using Newtonsoft.Json;
+using UserCom.Serialization;
 
 namespace UserCom.Model.Attributes
 {
@@ -13,7 +14,7 @@ namespace UserCom.Model.Attributes
         [JsonProperty("name")]
         public string Name { get; set; }
 
-        [JsonProperty("value")]
+        [JsonProperty("value"), JsonConverter(typeof(AttributeValueConverter))]
         public string Value { get; set; }
     }
 }

--- a/src/UserCom.Client/Model/Attributes/ValueType.cs
+++ b/src/UserCom.Client/Model/Attributes/ValueType.cs
@@ -5,18 +5,18 @@ namespace UserCom.Model.Attributes
     public enum ValueType
     {
         [EnumMember(Value = "boolean")]
-        Boolean,
+        Boolean = 1,
         [EnumMember(Value = "integer")]
-        Integer,
+        Integer = 2,
         [EnumMember(Value = "date")]
-        Date,
+        Date = 3,
         [EnumMember(Value = "string")]
-        String,
+        String = 4,
         [EnumMember(Value = "datetime")]
-        Datetime,
+        Datetime = 5,
         [EnumMember(Value = "fixed")]
-        Fixed,
+        Fixed = 6,
         [EnumMember(Value = "float")]
-        Float
+        Float = 7
     }
 }

--- a/src/UserCom.Client/Serialization/AttributeValueConverter.cs
+++ b/src/UserCom.Client/Serialization/AttributeValueConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.Linq;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 
@@ -35,7 +36,7 @@ namespace UserCom.Serialization
             else if (Regex.IsMatch(strValue, ArrayRegex))
             {
                 var arrayStr = strValue.Replace("[", "").Replace("]", "");
-                var arrayValue = arrayStr.Split(',');
+                var arrayValue = arrayStr.Split(',').Select(s => s.Replace("\"", ""));
 
                 serializer.Serialize(writer, arrayValue);
             }
@@ -83,7 +84,7 @@ namespace UserCom.Serialization
             {
                 var arrayValue = serializer.Deserialize<string[]>(reader);
 
-                return $"[{string.Join(",", arrayValue)}]";
+                return $"[{string.Join(",", arrayValue.Select(s => $"\"{s}\""))}]";
             }
             catch { }
 

--- a/src/UserCom.Client/Serialization/AttributeValueConverter.cs
+++ b/src/UserCom.Client/Serialization/AttributeValueConverter.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json;
+
+namespace UserCom.Serialization
+{
+    public class AttributeValueConverter : JsonConverter
+    {
+        private const string ArrayRegex = @"^\[.*\]$";
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var strValue = value.ToString();
+            if (bool.TryParse(strValue, out var boolValue))
+            {
+                serializer.Serialize(writer, boolValue);
+            }
+            else if (int.TryParse(strValue, NumberStyles.Any, CultureInfo.InvariantCulture, out var intValue))
+            {
+                serializer.Serialize(writer, intValue);
+            }
+            else if (float.TryParse(strValue, NumberStyles.Any, CultureInfo.InvariantCulture, out var floatValue))
+            {
+                serializer.Serialize(writer, floatValue);
+            }
+            else if (double.TryParse(strValue, NumberStyles.Any, CultureInfo.InvariantCulture, out var doubleValue))
+            {
+                serializer.Serialize(writer, doubleValue);
+            }
+            else if (decimal.TryParse(strValue, NumberStyles.Any, CultureInfo.InvariantCulture, out var decimalValue))
+            {
+                serializer.Serialize(writer, decimalValue);
+            }
+            else if (Regex.IsMatch(strValue, ArrayRegex))
+            {
+                var arrayStr = strValue.Replace("[", "").Replace("]", "");
+                var arrayValue = arrayStr.Split(',');
+
+                serializer.Serialize(writer, arrayValue);
+            }
+            else
+            {
+                serializer.Serialize(writer, value);
+            }
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var value = reader.Value;
+
+            if (value is DateTime dateTimeValue)
+            {
+                return dateTimeValue.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+            }
+
+            if (value is bool boolValue)
+            {
+                return boolValue.ToString(CultureInfo.InvariantCulture).ToLowerInvariant();
+            }
+
+            if (value is float floatValue)
+            {
+                return floatValue.ToString(CultureInfo.InvariantCulture);
+            }
+
+            if (value is decimal decimalValue)
+            {
+                return decimalValue.ToString(CultureInfo.InvariantCulture);
+            }
+
+            if (value is double doubleValue)
+            {
+                return doubleValue.ToString(CultureInfo.InvariantCulture);
+            }
+
+            if (value is int intValue)
+            {
+                return intValue.ToString(CultureInfo.InvariantCulture);
+            }
+
+            try
+            {
+                var arrayValue = serializer.Deserialize<string[]>(reader);
+
+                return $"[{string.Join(",", arrayValue)}]";
+            }
+            catch { }
+
+            return value.ToString();
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return true;
+        }
+    }
+}

--- a/tests/UserCom/CustomAutoDataAttribute.cs
+++ b/tests/UserCom/CustomAutoDataAttribute.cs
@@ -1,0 +1,32 @@
+﻿using AutoFixture;
+using AutoFixture.AutoMoq;
+using AutoFixture.NUnit3;
+
+namespace Tests.UserCom
+{
+    public class CustomAutoDataAttribute : AutoDataAttribute
+    {
+        public CustomAutoDataAttribute() : base(FixtureHelper.CreateFixture) { }
+    }
+
+    public class InlineCustomAutoDataAttribute : InlineAutoDataAttribute
+    {
+        public InlineCustomAutoDataAttribute(params object[] arguments) : base(FixtureHelper.CreateFixture, arguments) { }
+    }
+
+    public static class FixtureHelper
+    {
+        public static IFixture CreateFixture()
+        {
+            var fixture = new Fixture();
+
+            fixture.Customize(new AutoMoqCustomization
+            {
+                ConfigureMembers = true,
+                GenerateDelegates = true
+            });
+
+            return fixture;
+        }
+    }
+}

--- a/tests/UserCom/Tests.UserCom.csproj
+++ b/tests/UserCom/Tests.UserCom.csproj
@@ -7,11 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.11.0" />
-    <PackageReference Include="Kralizek.AutoFixture.Extensions.MockHttp" Version="1.0.0" />
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.Idioms" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.NUnit3" Version="4.18.1" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\UserCom.Client\UserCom.Client.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/UserCom/UserSerializationTests.cs
+++ b/tests/UserCom/UserSerializationTests.cs
@@ -1,0 +1,254 @@
+﻿using System;
+using System.Globalization;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using UserCom;
+using UserCom.Model.Users;
+
+namespace Tests.UserCom
+{
+    [TestFixture]
+    public class UserSerializationTests
+    {
+        [TestFixture]
+        public class UserAttributeTests
+        {
+            [Test, CustomAutoData]
+            public void String_attribute_value_can_be_deserialized(string value)
+            {
+                var userStr = $"{{\"attributes\":[{{\"value\":\"{value}\"}}]}}";
+
+                var result = JsonConvert.DeserializeObject<User>(userStr, UserComClient.SerializerSettings);
+                
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result, Is.Not.Null);
+                    Assert.That(result.Attributes, Is.Not.Null);
+                    Assert.That(result.Attributes.Count, Is.EqualTo(1));
+                    Assert.That(result.Attributes[0].Value, Is.EqualTo(value));
+                });
+            }
+
+            [Test, CustomAutoData]
+            public void String_attribute_value_can_be_serialized(string value)
+            {
+                var userStr = $"{{\"attributes\":[{{\"value\":\"{value}\"}}]}}";
+
+                var user = JsonConvert.DeserializeObject<User>(userStr, UserComClient.SerializerSettings);
+                var result = JsonConvert.SerializeObject(user, UserComClient.SerializerSettings);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result, Is.Not.Null);
+                    Assert.That(result, Is.EqualTo(userStr));
+                });
+            }
+
+            [Test, CustomAutoData]
+            public void Boolean_attribute_value_can_be_deserialized(bool value)
+            {
+                var strValue = value.ToString().ToLower();
+
+                var userStr = $"{{\"attributes\":[{{\"value\":{strValue}}}]}}";
+
+                var result = JsonConvert.DeserializeObject<User>(userStr, UserComClient.SerializerSettings);
+                
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result, Is.Not.Null);
+                    Assert.That(result.Attributes, Is.Not.Null);
+                    Assert.That(result.Attributes.Count, Is.EqualTo(1));
+                    Assert.That(result.Attributes[0].Value, Is.EqualTo(strValue));
+                });
+            }
+
+            [Test, CustomAutoData]
+            public void Boolean_attribute_value_can_be_serialized(bool value)
+            {
+                var strValue = value.ToString().ToLower();
+
+                var userStr = $"{{\"attributes\":[{{\"value\":{strValue}}}]}}";
+
+                var user = JsonConvert.DeserializeObject<User>(userStr, UserComClient.SerializerSettings);
+                var result = JsonConvert.SerializeObject(user, UserComClient.SerializerSettings);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result, Is.Not.Null);
+                    Assert.That(result, Is.EqualTo(userStr));
+                });
+            }
+
+            [Test, CustomAutoData]
+            public void Integer_attribute_value_can_be_deserialized(int value)
+            {
+                var userStr = $"{{\"attributes\":[{{\"value\":{value}}}]}}";
+
+                var result = JsonConvert.DeserializeObject<User>(userStr, UserComClient.SerializerSettings);
+                
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result, Is.Not.Null);
+                    Assert.That(result.Attributes, Is.Not.Null);
+                    Assert.That(result.Attributes.Count, Is.EqualTo(1));
+                    Assert.That(result.Attributes[0].Value, Is.EqualTo(value.ToString()));
+                });
+            }
+
+            [Test, CustomAutoData]
+            public void Integer_attribute_value_can_be_serialized(int value)
+            {
+                var userStr = $"{{\"attributes\":[{{\"value\":{value}}}]}}";
+
+                var user = JsonConvert.DeserializeObject<User>(userStr, UserComClient.SerializerSettings);
+                var result = JsonConvert.SerializeObject(user, UserComClient.SerializerSettings);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result, Is.Not.Null);
+                    Assert.That(result, Is.EqualTo(userStr));
+                });
+            }
+
+            [Test, CustomAutoData]
+            public void Float_attribute_value_can_be_deserialized(float value)
+            {
+                value /= 10;
+                var strValue = value.ToString(CultureInfo.InvariantCulture);
+
+                var userStr = $"{{\"attributes\":[{{\"value\":{strValue}}}]}}";
+
+                var result = JsonConvert.DeserializeObject<User>(userStr, UserComClient.SerializerSettings);
+                
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result, Is.Not.Null);
+                    Assert.That(result.Attributes, Is.Not.Null);
+                    Assert.That(result.Attributes.Count, Is.EqualTo(1));
+                    Assert.That(result.Attributes[0].Value, Is.EqualTo(strValue));
+                });
+            }
+
+            [Test, CustomAutoData]
+            public void Float_attribute_value_can_be_serialized(float value)
+            {
+                value /= 10;
+                var strValue = value.ToString(CultureInfo.InvariantCulture);
+
+                var userStr = $"{{\"attributes\":[{{\"value\":{strValue}}}]}}";
+
+                var user = JsonConvert.DeserializeObject<User>(userStr, UserComClient.SerializerSettings);
+                var result = JsonConvert.SerializeObject(user, UserComClient.SerializerSettings);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result, Is.Not.Null);
+                    Assert.That(result, Is.EqualTo(userStr));
+                });
+            }
+
+            [Test, CustomAutoData]
+            public void DateTime_attribute_value_can_be_deserialized(DateTime value)
+            {
+                var strValue = value.ToString("yyyy-MM-ddTHH:mm:ssZ");
+
+                var userStr = $"{{\"attributes\":[{{\"value\":\"{strValue}\"}}]}}";
+
+                var result = JsonConvert.DeserializeObject<User>(userStr, UserComClient.SerializerSettings);
+                
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result, Is.Not.Null);
+                    Assert.That(result.Attributes, Is.Not.Null);
+                    Assert.That(result.Attributes.Count, Is.EqualTo(1));
+                    Assert.That(result.Attributes[0].Value, Is.EqualTo(strValue));
+                });
+            }
+
+            [Test, CustomAutoData]
+            public void DateTime_attribute_value_can_be_serialized(DateTime value)
+            {
+                var strValue = value.ToString("yyyy-MM-ddTHH:mm:ssZ");
+
+                var userStr = $"{{\"attributes\":[{{\"value\":\"{strValue}\"}}]}}";
+
+                var user = JsonConvert.DeserializeObject<User>(userStr, UserComClient.SerializerSettings);
+                var result = JsonConvert.SerializeObject(user, UserComClient.SerializerSettings);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result, Is.Not.Null);
+                    Assert.That(result, Is.EqualTo(userStr));
+                });
+            }
+
+            [Test, CustomAutoData]
+            public void Date_attribute_value_can_be_deserialized(DateTime value)
+            {
+                var strValue = value.Date.ToString("yyyy-MM-dd");
+
+                var userStr = $"{{\"attributes\":[{{\"value\":\"{strValue}\"}}]}}";
+
+                var result = JsonConvert.DeserializeObject<User>(userStr, UserComClient.SerializerSettings);
+                
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result, Is.Not.Null);
+                    Assert.That(result.Attributes, Is.Not.Null);
+                    Assert.That(result.Attributes.Count, Is.EqualTo(1));
+                    Assert.That(result.Attributes[0].Value, Is.EqualTo(strValue));
+                });
+            }
+
+            [Test, CustomAutoData]
+            public void Date_attribute_value_can_be_serialized(DateTime value)
+            {
+                var strValue = value.Date.ToString("yyyy-MM-dd");
+
+                var userStr = $"{{\"attributes\":[{{\"value\":\"{strValue}\"}}]}}";
+
+                var user = JsonConvert.DeserializeObject<User>(userStr, UserComClient.SerializerSettings);
+                var result = JsonConvert.SerializeObject(user, UserComClient.SerializerSettings);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result, Is.Not.Null);
+                    Assert.That(result, Is.EqualTo(userStr));
+                });
+            }
+
+            [Test, CustomAutoData]
+            public void Fixed_aka_array_attribute_value_can_be_deserialized(
+                string value)
+            {
+                var userStr = $"{{\"attributes\":[{{\"value\":[\"{value}\"]}}]}}";
+
+                var result = JsonConvert.DeserializeObject<User>(userStr, UserComClient.SerializerSettings);
+                
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result, Is.Not.Null);
+                    Assert.That(result.Attributes, Is.Not.Null);
+                    Assert.That(result.Attributes.Count, Is.EqualTo(1));
+                    Assert.That(result.Attributes[0].Value, Is.EqualTo($"[{value}]"));
+                });
+            }
+
+            [Test, CustomAutoData]
+            public void Fixed_aka_array_attribute_value_can_be_serialized(
+                string value)
+            {
+                var userStr = $"{{\"attributes\":[{{\"value\":[\"{value}\"]}}]}}";
+
+                var user = JsonConvert.DeserializeObject<User>(userStr, UserComClient.SerializerSettings);
+                var result = JsonConvert.SerializeObject(user, UserComClient.SerializerSettings);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result, Is.Not.Null);
+                    Assert.That(result, Is.EqualTo(userStr));
+                });
+            }
+        }
+    }
+}

--- a/tests/UserCom/UserSerializationTests.cs
+++ b/tests/UserCom/UserSerializationTests.cs
@@ -230,7 +230,7 @@ namespace Tests.UserCom
                     Assert.That(result, Is.Not.Null);
                     Assert.That(result.Attributes, Is.Not.Null);
                     Assert.That(result.Attributes.Count, Is.EqualTo(1));
-                    Assert.That(result.Attributes[0].Value, Is.EqualTo($"[{value}]"));
+                    Assert.That(result.Attributes[0].Value, Is.EqualTo($"[\"{value}\"]"));
                 });
             }
 


### PR DESCRIPTION
Some attribute values are in the form of an array, and that causes the de-serialization to break.

- Added AttributeValueConverter for handling the serialization/deserialization of the Value of the attribute. Converts between the value in json, and the type string used in the class
- Added unit tests for serialization/deserialization of users with focus on the different attribute types to validate that all types can safely be serialized/deserialized.

This is an example (for a test user) what the response looks like for user attributes from the user.com api (using the `/api/public/users-by-id/:custom_id/` endpoint)

```
{
    "attributes": [
        {
            "id": 20,
            "name": "test_boolean",
            "name_std": "test_boolean",
            "value": true,
            "description": "Test attribute of type boolean",
            "value_type": 1
        },
        {
            "id": 19,
            "name": "test_string",
            "name_std": "test_string",
            "value": "hello world",
            "description": "Test attribute of type string",
            "value_type": 4
        },
        {
            "id": 22,
            "name": "test_date",
            "name_std": "test_date",
            "value": "2025-09-18",
            "description": "Test attribute of type date",
            "value_type": 3
        },
        {
            "id": 23,
            "name": "test_datetime",
            "name_std": "test_datetime",
            "value": "2025-09-27T16:09:00Z",
            "description": "Test attribute of type datetime",
            "value_type": 5
        },
        {
            "id": 24,
            "name": "test_integer",
            "name_std": "test_integer",
            "value": 23,
            "description": "Test attribute of type integer",
            "value_type": 2
        },
        {
            "id": 25,
            "name": "test_float",
            "name_std": "test_float",
            "value": 7.4,
            "description": "Test attribute of type float",
            "value_type": 7
        },
        {
            "id": 21,
            "name": "test_fixed",
            "name_std": "test_fixed",
            "value": [
                "first_option"
            ],
            "description": "Test attribute of type fixed",
            "value_type": 6
        }
    ]
}
```