### PR TITLE
COREX-2041 - User.com sync issue

### DIFF
--- a/src/UserCom.Client/UserComClient.cs
+++ b/src/UserCom.Client/UserComClient.cs
@@ -48,12 +48,12 @@ namespace UserCom
                     }
                     catch (HttpException httpException) when (httpException.StatusCode == System.Net.HttpStatusCode.NotFound)
                     {
-                        return new PaginatedResult<T>() { Results = new T[0] };
+                        return new PaginatedResult<T>() { Results = Array.Empty<T>() };
                     }
                     catch (AggregateException aggregateException)
                         when (aggregateException.InnerException is HttpException httpException && httpException.StatusCode == System.Net.HttpStatusCode.NotFound)
                     {
-                        return new PaginatedResult<T>() { Results = new T[0] };
+                        return new PaginatedResult<T>() { Results = Array.Empty<T>() };
                     }
                 });
             }

--- a/tests/UserCom/UserComClientListTests.cs
+++ b/tests/UserCom/UserComClientListTests.cs
@@ -46,7 +46,7 @@ namespace Tests.UserCom
                         Content = new StringContent(JsonConvert.SerializeObject(new
                         {
                             count = 0,
-                            results = new object[0],
+                            results = Array.Empty<object>(),
                             next = $"https://{account}.user.com{nextUrl}"
                         })),
                         RequestMessage = new HttpRequestMessage(HttpMethod.Get, listAllUrl)
@@ -119,7 +119,7 @@ namespace Tests.UserCom
                         Content = new StringContent(JsonConvert.SerializeObject(new
                         {
                             count = 0,
-                            results = new object[0],
+                            results = Array.Empty<object>(),
                             next = $"https://{account}.user.com{nextUrl}"
                         })),
                         RequestMessage = new HttpRequestMessage(HttpMethod.Get, listAllUrl)

--- a/tests/UserCom/UserComClientListTests.cs
+++ b/tests/UserCom/UserComClientListTests.cs
@@ -1,0 +1,164 @@
+﻿using AutoFixture.NUnit3;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Security.Principal;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using UserCom;
+
+namespace Tests.UserCom
+{
+    [TestFixture]
+    public class UserComClientListTest
+    {
+        private const string ListResource = "/api/public/lists";
+
+        [TestFixture]
+        public class PaginatedResult_Next
+        {
+            [Test, CustomAutoData]
+            public async Task PaginatedResult_Next_does_not_throw_if_nextUrl_from_userCom_throws_404(
+                ILogger<UserComClient> logger,
+                Mock<HttpMessageHandler> handler,
+                string account)
+            {
+                var listAllUrl = $"{ListResource}/";
+                var nextUrl = $"{ListResource}?cursor=101";
+                
+                // Initial request in GetAllAsync
+                handler.Protected()
+                    .Setup<Task<HttpResponseMessage>>(
+                        "SendAsync",
+                        ItExpr.Is<HttpRequestMessage>(m => m.RequestUri.PathAndQuery.Equals(listAllUrl)),
+                        ItExpr.IsAny<CancellationToken>())
+                    .ReturnsAsync(() => new HttpResponseMessage
+                    {
+                        StatusCode = HttpStatusCode.OK,
+                        Content = new StringContent(JsonConvert.SerializeObject(new
+                        {
+                            count = 0,
+                            results = new object[0],
+                            next = $"https://{account}.user.com{nextUrl}"
+                        })),
+                        RequestMessage = new HttpRequestMessage(HttpMethod.Get, listAllUrl)
+                    });
+
+                // "Next" request
+                handler.Protected()
+                    .Setup<Task<HttpResponseMessage>>(
+                        "SendAsync",
+                        ItExpr.Is<HttpRequestMessage>(m => m.RequestUri.PathAndQuery.Equals(nextUrl)),
+                        ItExpr.IsAny<CancellationToken>())
+                    .ReturnsAsync(() => new HttpResponseMessage
+                    {
+                        StatusCode = HttpStatusCode.NotFound,
+                        Content = new StringContent(JsonConvert.SerializeObject(new { })),
+                        RequestMessage = new HttpRequestMessage(HttpMethod.Get, nextUrl)
+                    });
+
+                var authenticator = new UserComAuthenticator(account)
+                {
+                    InnerHandler = handler.Object
+                };
+
+                var sut = new UserComClient(authenticator, logger);
+
+                var initial = await sut.Lists.GetAllAsync();
+
+                Assert.DoesNotThrow(() =>
+                {
+                    var next = initial.Next.Value;
+                });
+
+                handler.Protected().Verify(
+                    "SendAsync",
+                    Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get && req.RequestUri.PathAndQuery.Equals(listAllUrl)),
+                    ItExpr.IsAny<CancellationToken>());
+
+                handler.Protected().Verify(
+                   "SendAsync",
+                   Times.Once(),
+                   ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get && req.RequestUri.PathAndQuery.Equals(nextUrl)),
+                   ItExpr.IsAny<CancellationToken>());
+
+                handler.Protected().Verify(
+                    "SendAsync",
+                    Times.Exactly(2),
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>());
+            }
+
+            [Test, CustomAutoData]
+            public async Task PaginatedResult_Next_returns_empty_paginatedResult_if_nextUrl_from_userCom_throws_404(
+                ILogger<UserComClient> logger,
+                Mock<HttpMessageHandler> handler,
+                string account)
+            {
+                var listAllUrl = $"{ListResource}/";
+                var nextUrl = $"{ListResource}?cursor=101";
+
+                // Initial request in GetAllAsync
+                handler.Protected()
+                    .Setup<Task<HttpResponseMessage>>(
+                        "SendAsync",
+                        ItExpr.Is<HttpRequestMessage>(m => m.RequestUri.PathAndQuery.Equals(listAllUrl)),
+                        ItExpr.IsAny<CancellationToken>())
+                    .ReturnsAsync(() => new HttpResponseMessage
+                    {
+                        StatusCode = HttpStatusCode.OK,
+                        Content = new StringContent(JsonConvert.SerializeObject(new
+                        {
+                            count = 0,
+                            results = new object[0],
+                            next = $"https://{account}.user.com{nextUrl}"
+                        })),
+                        RequestMessage = new HttpRequestMessage(HttpMethod.Get, listAllUrl)
+                    });
+
+                // "Next" request
+                handler.Protected()
+                    .Setup<Task<HttpResponseMessage>>(
+                        "SendAsync",
+                        ItExpr.Is<HttpRequestMessage>(m => m.RequestUri.PathAndQuery.Equals(nextUrl)),
+                        ItExpr.IsAny<CancellationToken>())
+                    .ReturnsAsync(() => new HttpResponseMessage
+                    {
+                        StatusCode = HttpStatusCode.NotFound,
+                        Content = new StringContent(JsonConvert.SerializeObject(new { })),
+                        RequestMessage = new HttpRequestMessage(HttpMethod.Get, nextUrl)
+                    });
+
+                var authenticator = new UserComAuthenticator(account)
+                {
+                    InnerHandler = handler.Object
+                };
+
+                var sut = new UserComClient(authenticator, logger);
+
+                var initial = await sut.Lists.GetAllAsync();
+
+                var result = initial.Next.Value;
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result, Is.Not.Null);
+                    Assert.That(result.Count, Is.EqualTo(0));
+                    Assert.That(result.Results, Is.Not.Null);
+                    Assert.That(result.Results.Count, Is.EqualTo(0));
+                    Assert.That(result.Next, Is.Null);
+                    Assert.That(result.Previous, Is.Null);
+                });
+            }
+        }
+    }
+}


### PR DESCRIPTION
Updated CreatePaginatedResult used when getting lists due to bug in user.com API where the "next" endpoint gives 404.