### PR TITLE
COREX-2041 - User.com sync issue

### DIFF
--- a/src/UserCom.Client/Model/Lists/Requests/UpdateOrCreateListRequest.cs
+++ b/src/UserCom.Client/Model/Lists/Requests/UpdateOrCreateListRequest.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace UserCom.Model.Lists.Requests
+{
+    public class UpdateOrCreateListRequest
+    {
+        [JsonProperty("name")]
+        public string? Name { get; set; }
+        
+        [JsonProperty("description")]
+        public string? Description { get; set; }
+    }
+}

--- a/src/UserCom.Client/Model/Users/Requests/UpdateOrCreateUserRequest.cs
+++ b/src/UserCom.Client/Model/Users/Requests/UpdateOrCreateUserRequest.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using Newtonsoft.Json;
+using UserCom.Serialization;
 
 namespace UserCom.Model.Users.Requests
 {
@@ -9,7 +10,7 @@ namespace UserCom.Model.Users.Requests
         [JsonProperty("assigned_to")]
         public int? AssignedTo { get; set; }
 
-        [JsonProperty("city")]
+        [JsonProperty("city"), JsonConverter(typeof(StringValueMaxLengthConverter), 64)]
         public string? City { get; set; }
 
         [JsonProperty("company_id")]
@@ -24,7 +25,7 @@ namespace UserCom.Model.Users.Requests
         [JsonProperty("facebook_url")]
         public string? FacebookUrl { get; set; }
 
-        [JsonProperty("first_name")]
+        [JsonProperty("first_name"), JsonConverter(typeof(StringValueMaxLengthConverter), 40)]
         public string? FirstName { get; set; }
 
         [JsonProperty("gender")]
@@ -36,7 +37,7 @@ namespace UserCom.Model.Users.Requests
         [JsonProperty("gravatar_url")]
         public string? GravatarUrl { get; set; }
 
-        [JsonProperty("last_name")]
+        [JsonProperty("last_name"), JsonConverter(typeof(StringValueMaxLengthConverter), 40)]
         public string? LastName { get; set; }
 
         [JsonProperty("linkedin_url")]
@@ -45,7 +46,7 @@ namespace UserCom.Model.Users.Requests
         [JsonProperty("notifications")]
         public bool? Notifications { get; set; }
 
-        [JsonProperty("phone_number")]
+        [JsonProperty("phone_number"), JsonConverter(typeof(StringValueMaxLengthConverter), 64)]
         public string? PhoneNumber { get; set; }
 
         [JsonProperty("region")]

--- a/src/UserCom.Client/Serialization/StringValueMaxLengthConverter.cs
+++ b/src/UserCom.Client/Serialization/StringValueMaxLengthConverter.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace UserCom.Serialization
+{
+    public class StringValueMaxLengthConverter : JsonConverter
+    {
+        private readonly int _maxLength;
+
+        public StringValueMaxLengthConverter(int maxLength)
+        {
+            _maxLength = maxLength;
+        }
+
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+        {
+            var strValue = value?.ToString();
+
+            if (!string.IsNullOrEmpty(strValue) && strValue.Length > _maxLength)
+            {
+                var substring = $"{strValue.Substring(0, _maxLength - 3)}...";
+                
+                serializer.Serialize(writer, substring);
+            }
+            else
+            {
+                serializer.Serialize(writer, strValue);
+            }
+        }
+
+        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(string);
+        }
+
+        public override bool CanRead => false;
+        public override bool CanWrite => true;
+    }
+}

--- a/src/UserCom.Client/UserComClient.Lists.cs
+++ b/src/UserCom.Client/UserComClient.Lists.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using UserCom.Model;
 using UserCom.Model.Lists;
+using UserCom.Model.Lists.Requests;
 
 namespace UserCom
 {
@@ -11,7 +12,8 @@ namespace UserCom
 
         async Task<List> IUserComListsClient.CreateAsync(string name, string description)
         {
-            var result = await SendAsync<dynamic, List>(HttpMethod.Post, $"{LISTS_RESOURCE}/", new { name, description });
+            var request = new UpdateOrCreateListRequest { Name = name, Description = description };
+            var result = await SendAsync<UpdateOrCreateListRequest, List>(HttpMethod.Post, $"{LISTS_RESOURCE}/", request);
 
             return result;
         }
@@ -31,7 +33,8 @@ namespace UserCom
 
         async Task IUserComListsClient.UpdateAsync(int id, string? name, string? description)
         {
-            await SendAsync<dynamic>(HttpMethod.Put, $"{LISTS_RESOURCE}/{id}/", new { name, description });
+            var request = new UpdateOrCreateListRequest { Name = name, Description = description };
+            await SendAsync<UpdateOrCreateListRequest>(HttpMethod.Put, $"{LISTS_RESOURCE}/{id}/", request);
         }
     }
 }

--- a/tests/UserCom/Serialization/StringValueMaxLengthConverterTestBase.cs
+++ b/tests/UserCom/Serialization/StringValueMaxLengthConverterTestBase.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Linq;
+using AutoFixture;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using UserCom;
+
+namespace Tests.UserCom.Serialization;
+
+public abstract class StringValueMaxLengthConverterTestBase<TType> where TType : class, new()
+{
+    protected abstract string GetJsonStr(string value);
+
+    protected abstract int MaxLength { get; }
+
+    protected abstract string GetValue(TType obj);
+
+    protected abstract TType CreateObj(string value);
+
+    private static string GenerateString(IFixture fixture, int length)
+    {
+        var s = string.Empty;
+        while (s.Length < length)
+        {
+            s += fixture.Create<string>();
+        }
+        if (s.Length > length)
+        {
+            s = s[..length];
+        }
+
+        return s;
+    }
+
+    [Test, CustomAutoData]
+    public void Empty_object_can_be_serialized(
+        IFixture fixture, Random random)
+    {
+        var obj = new TType();
+
+        var result = JsonConvert.SerializeObject(obj, UserComClient.SerializerSettings);
+
+        Assert.That(result, Is.EqualTo("{}"));
+    }
+
+    [Test, CustomAutoData]
+    public void Empty_object_can_be_deserialized(
+        IFixture fixture, Random random)
+    {
+        var objStr = "{}";
+
+        var result = JsonConvert.DeserializeObject<TType>(objStr, UserComClient.SerializerSettings);
+
+        Assert.That(GetValue(result), Is.Null);
+    }
+
+    [Test, CustomAutoData]
+    public void Property_value_with_length_equal_to_MaxLength_can_be_serialized(
+        IFixture fixture, Random random)
+    {
+        var obj = CreateObj(GenerateString(fixture, MaxLength));
+
+        var result = JsonConvert.SerializeObject(obj, UserComClient.SerializerSettings);
+
+        Assert.That(result, Is.EqualTo(GetJsonStr(GetValue(obj))));
+    }
+
+    [Test, CustomAutoData]
+    public void Property_value_with_length_equal_to_MaxLength_can_be_deserialized(
+        IFixture fixture, Random random)
+    {
+        var value = GenerateString(fixture, MaxLength);
+        var objStr = GetJsonStr(value);
+
+        var result = JsonConvert.DeserializeObject<TType>(objStr, UserComClient.SerializerSettings);
+
+        Assert.That(GetValue(result), Is.EqualTo(value));
+    }
+
+    [Test, CustomAutoData]
+    public void Property_value_with_length_less_than_MaxLength_can_be_serialized(
+        IFixture fixture, Random random)
+    {
+        var value = GenerateString(fixture, random.Next(1, MaxLength));
+        var obj = CreateObj(value);
+        
+        var result = JsonConvert.SerializeObject(obj, UserComClient.SerializerSettings);
+
+        Assert.That(result, Is.EqualTo(GetJsonStr(value)));
+    }
+
+    [Test, CustomAutoData]
+    public void Property_value_with_length_less_than_MaxLength_can_be_deserialized(
+        IFixture fixture, Random random)
+    {
+        var value = GenerateString(fixture, random.Next(1, MaxLength));
+        var objStr = GetJsonStr(value);
+
+        var result = JsonConvert.DeserializeObject<TType>(objStr, UserComClient.SerializerSettings);
+
+        Assert.That(GetValue(result), Is.EqualTo(value));
+    }
+
+    [Test, CustomAutoData]
+    public void Property_value_with_length_more_than_MaxLength_can_be_serialized(
+        IFixture fixture, Random random)
+    {
+        var value = GenerateString(fixture, random.Next(MaxLength + 1, fixture.Create<Generator<int>>().First(i => i > MaxLength + 1)));
+        var obj = CreateObj(value);
+
+        var result = JsonConvert.SerializeObject(obj, UserComClient.SerializerSettings);
+
+        var expectedValue = $"{value.Substring(0, MaxLength - 3)}...";
+        Assert.That(result, Is.EqualTo(GetJsonStr(expectedValue)));
+    }
+
+    [Test, CustomAutoData]
+    public void Property_value_with_length_more_than_MaxLength_can_be_deserialized(
+        IFixture fixture, Random random)
+    {
+        var value = GenerateString(fixture, random.Next(MaxLength + 1, fixture.Create<Generator<int>>().First(i => i > MaxLength + 1)));
+        var objStr = GetJsonStr(value);
+
+        var result = JsonConvert.DeserializeObject<TType>(objStr, UserComClient.SerializerSettings);
+
+        Assert.That(GetValue(result), Is.EqualTo(value));
+    }
+
+}

--- a/tests/UserCom/Serialization/UpdateOrCreateUserRequestSerializationTests.cs
+++ b/tests/UserCom/Serialization/UpdateOrCreateUserRequestSerializationTests.cs
@@ -1,0 +1,56 @@
+﻿using NUnit.Framework;
+using UserCom.Model.Users.Requests;
+
+namespace Tests.UserCom.Serialization;
+
+[TestFixture]
+public class UpdateOrCreateUserRequestSerializationTests
+{
+    [TestFixture]
+    public class FirstNameSerializationTests : StringValueMaxLengthConverterTestBase<UpdateOrCreateUserRequest>
+    {
+        protected override string GetJsonStr(string value) => $"{{\"first_name\":\"{value}\"}}";
+
+        protected override int MaxLength => 40;
+
+        protected override string GetValue(UpdateOrCreateUserRequest obj) => obj.FirstName;
+
+        protected override UpdateOrCreateUserRequest CreateObj(string value) => new() { FirstName = value };
+    }
+
+    [TestFixture]
+    public class LastNameSerializationTests : StringValueMaxLengthConverterTestBase<UpdateOrCreateUserRequest>
+    {
+        protected override string GetJsonStr(string value) => $"{{\"last_name\":\"{value}\"}}";
+
+        protected override int MaxLength => 40;
+
+        protected override string GetValue(UpdateOrCreateUserRequest obj) => obj.LastName;
+
+        protected override UpdateOrCreateUserRequest CreateObj(string value) => new() { LastName = value };
+    }
+
+    [TestFixture]
+    public class CitySerializationTests : StringValueMaxLengthConverterTestBase<UpdateOrCreateUserRequest>
+    {
+        protected override string GetJsonStr(string value) => $"{{\"city\":\"{value}\"}}";
+
+        protected override int MaxLength => 64;
+
+        protected override string GetValue(UpdateOrCreateUserRequest obj) => obj.City;
+
+        protected override UpdateOrCreateUserRequest CreateObj(string value) => new() { City = value };
+    }
+
+    [TestFixture]
+    public class PhoneNumberSerializationTests : StringValueMaxLengthConverterTestBase<UpdateOrCreateUserRequest>
+    {
+        protected override string GetJsonStr(string value) => $"{{\"phone_number\":\"{value}\"}}";
+
+        protected override int MaxLength => 64;
+
+        protected override string GetValue(UpdateOrCreateUserRequest obj) => obj.PhoneNumber;
+
+        protected override UpdateOrCreateUserRequest CreateObj(string value) => new() { PhoneNumber = value };
+    }
+}

--- a/tests/UserCom/Serialization/UserSerializationTests.cs
+++ b/tests/UserCom/Serialization/UserSerializationTests.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 using UserCom;
 using UserCom.Model.Users;
 
-namespace Tests.UserCom
+namespace Tests.UserCom.Serialization
 {
     [TestFixture]
     public class UserSerializationTests


### PR DESCRIPTION
Added JsonConverter that crops the string when serializing if the value is too long (based on user.com requirements).
- Using converter for firstname, lastname, city and phonenumber
- Added tests