### PR TITLE
COREX-2344 Add extra custom fields

### DIFF
--- a/src/UserCom.Client/Model/Users/Requests/UpdateOrCreateUserRequest.cs
+++ b/src/UserCom.Client/Model/Users/Requests/UpdateOrCreateUserRequest.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using System;
 using Newtonsoft.Json;
 using UserCom.Serialization;
 
@@ -87,5 +88,11 @@ namespace UserCom.Model.Users.Requests
 
         [JsonProperty("next_education_start_year")]
         public int? NextEducationStartYear { get; set; }
+
+        [JsonProperty("Verified Member")]
+        public bool? VerifiedMember { get; set; }
+
+        [JsonProperty("Latest Member Login")]
+        public DateTime? LatestMemberLogin { get; set; }
     }
 }

--- a/src/UserCom.Client/Model/Users/Requests/UpdateOrCreateUserRequest.cs
+++ b/src/UserCom.Client/Model/Users/Requests/UpdateOrCreateUserRequest.cs
@@ -90,7 +90,7 @@ namespace UserCom.Model.Users.Requests
         public int? NextEducationStartYear { get; set; }
 
         [JsonProperty("Verified Member")]
-        public bool? VerifiedMember { get; set; }
+        public string? VerifiedMember { get; set; }
 
         [JsonProperty("Latest Member Login")]
         public DateTime? LatestMemberLogin { get; set; }

--- a/tests/UserCom/Serialization/UpdateOrCreateUserRequestSerializationTests.cs
+++ b/tests/UserCom/Serialization/UpdateOrCreateUserRequestSerializationTests.cs
@@ -1,4 +1,8 @@
-﻿using NUnit.Framework;
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using UserCom;
 using UserCom.Model.Users.Requests;
 
 namespace Tests.UserCom.Serialization;
@@ -6,6 +10,52 @@ namespace Tests.UserCom.Serialization;
 [TestFixture]
 public class UpdateOrCreateUserRequestSerializationTests
 {
+    private const string VerifiedMemberPropertyName = "Verified Member";
+    private const string LatestMemberLoginPropertyName = "Latest Member Login";
+
+    [Test, CustomAutoData]
+    public void VerifiedMember_serializes_using_expected_property_name(bool expectedVerifiedMemberValue)
+    {
+        var request = new UpdateOrCreateUserRequest { VerifiedMember = expectedVerifiedMemberValue };
+
+        var serialized = JsonConvert.SerializeObject(request, UserComClient.SerializerSettings);
+        var json = JObject.Parse(serialized);
+
+        Assert.That(json.ContainsKey(VerifiedMemberPropertyName), Is.True);
+        Assert.That((bool?)json[VerifiedMemberPropertyName], Is.EqualTo(expectedVerifiedMemberValue));
+    }
+
+    [Test, CustomAutoData]
+    public void VerifiedMember_deserializes_using_expected_property_name(bool expectedVerifiedMemberValue)
+    {
+        var json = $"{{\"{VerifiedMemberPropertyName}\":{expectedVerifiedMemberValue.ToString().ToLowerInvariant()}}}";
+        var deserialized = JsonConvert.DeserializeObject<UpdateOrCreateUserRequest>(json, UserComClient.SerializerSettings);
+        Assert.That(deserialized?.VerifiedMember, Is.EqualTo(expectedVerifiedMemberValue));
+    }
+
+    [Test, CustomAutoData]
+    public void LatestMemberLogin_serializes_using_expected_property_name(DateTime expectedLatestMemberLogin)
+    {
+        expectedLatestMemberLogin = expectedLatestMemberLogin.ToUniversalTime();
+        var request = new UpdateOrCreateUserRequest { LatestMemberLogin = expectedLatestMemberLogin };
+
+        var serialized = JsonConvert.SerializeObject(request, UserComClient.SerializerSettings);
+        var json = JObject.Parse(serialized);
+
+        Assert.That(json.ContainsKey(LatestMemberLoginPropertyName), Is.True);
+        var serializedValue = json[LatestMemberLoginPropertyName]?.ToObject<DateTime>();
+        Assert.That(serializedValue, Is.EqualTo(expectedLatestMemberLogin));
+    }
+
+    [Test, CustomAutoData]
+    public void LatestMemberLogin_deserializes_using_expected_property_name(DateTime expectedLatestMemberLogin)
+    {
+        expectedLatestMemberLogin = expectedLatestMemberLogin.ToUniversalTime();
+        var json = $"{{\"{LatestMemberLoginPropertyName}\":\"{expectedLatestMemberLogin:O}\"}}";
+        var deserialized = JsonConvert.DeserializeObject<UpdateOrCreateUserRequest>(json, UserComClient.SerializerSettings);
+        Assert.That(deserialized?.LatestMemberLogin, Is.EqualTo(expectedLatestMemberLogin));
+    }
+
     [TestFixture]
     public class FirstNameSerializationTests : StringValueMaxLengthConverterTestBase<UpdateOrCreateUserRequest>
     {

--- a/tests/UserCom/Serialization/UpdateOrCreateUserRequestSerializationTests.cs
+++ b/tests/UserCom/Serialization/UpdateOrCreateUserRequestSerializationTests.cs
@@ -14,7 +14,7 @@ public class UpdateOrCreateUserRequestSerializationTests
     private const string LatestMemberLoginPropertyName = "Latest Member Login";
 
     [Test, CustomAutoData]
-    public void VerifiedMember_serializes_using_expected_property_name(bool expectedVerifiedMemberValue)
+    public void VerifiedMember_serializes_using_expected_property_name(string expectedVerifiedMemberValue)
     {
         var request = new UpdateOrCreateUserRequest { VerifiedMember = expectedVerifiedMemberValue };
 
@@ -22,13 +22,13 @@ public class UpdateOrCreateUserRequestSerializationTests
         var json = JObject.Parse(serialized);
 
         Assert.That(json.ContainsKey(VerifiedMemberPropertyName), Is.True);
-        Assert.That((bool?)json[VerifiedMemberPropertyName], Is.EqualTo(expectedVerifiedMemberValue));
+        Assert.That((string?)json[VerifiedMemberPropertyName], Is.EqualTo(expectedVerifiedMemberValue));
     }
 
     [Test, CustomAutoData]
-    public void VerifiedMember_deserializes_using_expected_property_name(bool expectedVerifiedMemberValue)
+    public void VerifiedMember_deserializes_using_expected_property_name(string expectedVerifiedMemberValue)
     {
-        var json = $"{{\"{VerifiedMemberPropertyName}\":{expectedVerifiedMemberValue.ToString().ToLowerInvariant()}}}";
+        var json = $"{{\"{VerifiedMemberPropertyName}\":\"{expectedVerifiedMemberValue}\"}}";
         var deserialized = JsonConvert.DeserializeObject<UpdateOrCreateUserRequest>(json, UserComClient.SerializerSettings);
         Assert.That(deserialized?.VerifiedMember, Is.EqualTo(expectedVerifiedMemberValue));
     }


### PR DESCRIPTION
**New properties added to the `UpdateOrCreateUserRequest` model :**

- nullable string property `VerifiedMember`, JSON property name `Verified Member`
- nullable `DateTime` property `LatestMemberLogin` , JSON property name `Latest Member Login`

**Related tests:**

* Added serialization and deserialization tests for the new `VerifiedMember` and `LatestMemberLogin` properties, verifying correct JSON property naming and value handling.