### PR TITLE
COREX-3035 - usercom-dotnet-sdk - Resolve Codacy static analysis issues

### DIFF
--- a/src/UserCom.Client/FilterExtensions.cs
+++ b/src/UserCom.Client/FilterExtensions.cs
@@ -21,7 +21,7 @@ namespace UserCom
 
         public static (string key, string value) ToQueryParam(this CustomAttributeFilter filter)
         {
-            return ($"{filter.Name}{CustomAttributeLookupSuffixes[filter.Lookup]}", filter.Value.ToString());
+            return ($"{filter.Name}{CustomAttributeLookupSuffixes[filter.Lookup]}", System.Convert.ToString(filter.Value, System.Globalization.CultureInfo.InvariantCulture)!);
         }
 
         public static (string key, string value) ToQueryParam(this UserFilter filter)

--- a/src/UserCom.Client/FilterExtensions.cs
+++ b/src/UserCom.Client/FilterExtensions.cs
@@ -1,24 +1,27 @@
+using System.Collections.Generic;
 using UserCom.Model.Users;
 
 namespace UserCom
 {
     public static class FilterExtensions
     {
+        private static readonly Dictionary<CustomAttributeLookup, string> CustomAttributeLookupSuffixes = new Dictionary<CustomAttributeLookup, string>()
+        {
+            [CustomAttributeLookup.Contains] = "__contains",
+            [CustomAttributeLookup.ContainsCaseInsensitive] = "__icontains",
+            [CustomAttributeLookup.EndsWith] = "__endswith",
+            [CustomAttributeLookup.EndsWithCaseInsensitive] = "__iendswith",
+            [CustomAttributeLookup.StartsWith] = "__startswith",
+            [CustomAttributeLookup.StartsWithCaseInsensitive] = "__istartswith",
+            [CustomAttributeLookup.GreaterThan] = "__gt",
+            [CustomAttributeLookup.GreaterOrEqualThan] = "__gte",
+            [CustomAttributeLookup.LessThan] = "__lt",
+            [CustomAttributeLookup.LessOrEqualThan] = "__lte"
+        };
+
         public static (string key, string value) ToQueryParam(this CustomAttributeFilter filter)
         {
-            return (filter.Lookup switch
-            {
-                CustomAttributeLookup.Contains => $"{filter.Name}__contains",
-                CustomAttributeLookup.ContainsCaseInsensitive => $"{filter.Name}__icontains",
-                CustomAttributeLookup.EndsWith => $"{filter.Name}__endswith",
-                CustomAttributeLookup.EndsWithCaseInsensitive => $"{filter.Name}__iendswith",
-                CustomAttributeLookup.StartsWith => $"{filter.Name}__startswith",
-                CustomAttributeLookup.StartsWithCaseInsensitive => $"{filter.Name}__istartswith",
-                CustomAttributeLookup.GreaterThan => $"{filter.Name}__gt",
-                CustomAttributeLookup.GreaterOrEqualThan => $"{filter.Name}__gte",
-                CustomAttributeLookup.LessThan => $"{filter.Name}__lt",
-                CustomAttributeLookup.LessOrEqualThan => $"{filter.Name}__lte"
-            }, filter.Value.ToString());
+            return ($"{filter.Name}{CustomAttributeLookupSuffixes[filter.Lookup]}", filter.Value.ToString());
         }
 
         public static (string key, string value) ToQueryParam(this UserFilter filter)

--- a/src/UserCom.Client/FilterExtensions.cs
+++ b/src/UserCom.Client/FilterExtensions.cs
@@ -5,7 +5,7 @@ namespace UserCom
 {
     public static class FilterExtensions
     {
-        private static readonly Dictionary<CustomAttributeLookup, string> CustomAttributeLookupSuffixes = new Dictionary<CustomAttributeLookup, string>()
+        private static readonly Dictionary<CustomAttributeLookup, string> CustomAttributeLookupSuffixes = new Dictionary<CustomAttributeLookup, string>
         {
             [CustomAttributeLookup.Contains] = "__contains",
             [CustomAttributeLookup.ContainsCaseInsensitive] = "__icontains",

--- a/src/UserCom.Client/Http/HttpQueryStringBuilder.cs
+++ b/src/UserCom.Client/Http/HttpQueryStringBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace UserCom.Http
@@ -25,7 +26,7 @@ namespace UserCom.Http
 
         public void Add(string key, bool value) => Add(key, value ? "true" : "false");
 
-        public void Add<T>(string key, T value) where T : IConvertible => Add(key, (string)Convert.ChangeType(value, typeof(string)));
+        public void Add<T>(string key, T value) where T : IConvertible => Add(key, (string)Convert.ChangeType(value, typeof(string), CultureInfo.InvariantCulture));
 
         public QueryString BuildQuery(bool sortKeys = true, string? collateKeysBy = null)
         {

--- a/src/UserCom.Client/Http/UserComClientException.cs
+++ b/src/UserCom.Client/Http/UserComClientException.cs
@@ -6,11 +6,11 @@ namespace UserCom.Http
 {
     public class UserComClientException : Exception
     {
-        public HttpMethod Method { get; }
-        public string RequestUri { get; }
+        public HttpMethod? Method { get; }
+        public string? RequestUri { get; }
         public HttpStatusCode StatusCode { get; }
-        public string ReasonPhrase { get; }
-        public string ErrorMessage { get; }
+        public string? ReasonPhrase { get; }
+        public string? ErrorMessage { get; }
 
         public UserComClientException() { }
 

--- a/src/UserCom.Client/Http/UserComClientException.cs
+++ b/src/UserCom.Client/Http/UserComClientException.cs
@@ -12,7 +12,13 @@ namespace UserCom.Http
         public string ReasonPhrase { get; }
         public string ErrorMessage { get; }
 
-        public UserComClientException(HttpMethod method, string requestUri, HttpStatusCode statusCode, string reasonPhrase, string errorMessage, Exception? innerException = null) 
+        public UserComClientException() { }
+
+        public UserComClientException(string message) : base(message) { }
+
+        public UserComClientException(string message, Exception innerException) : base(message, innerException) { }
+
+        public UserComClientException(HttpMethod method, string requestUri, HttpStatusCode statusCode, string reasonPhrase, string errorMessage, Exception? innerException = null)
             : base($"{method}: {requestUri} {statusCode:G} '{reasonPhrase}' '{errorMessage}'", innerException)
         {
             Method = method;

--- a/src/UserCom.Client/Model/Users/Requests/UpdateOrCreateUserRequest.cs
+++ b/src/UserCom.Client/Model/Users/Requests/UpdateOrCreateUserRequest.cs
@@ -8,10 +8,15 @@ namespace UserCom.Model.Users.Requests
 {
     public class UpdateOrCreateUserRequest
     {
+        public const int CityMaxLength = 64;
+        public const int FirstNameMaxLength = 40;
+        public const int LastNameMaxLength = 40;
+        public const int PhoneNumberMaxLength = 64;
+
         [JsonProperty("assigned_to")]
         public int? AssignedTo { get; set; }
 
-        [JsonProperty("city"), JsonConverter(typeof(StringValueMaxLengthConverter), 64)]
+        [JsonProperty("city"), JsonConverter(typeof(StringValueMaxLengthConverter), CityMaxLength)]
         public string? City { get; set; }
 
         [JsonProperty("company_id")]
@@ -26,7 +31,7 @@ namespace UserCom.Model.Users.Requests
         [JsonProperty("facebook_url")]
         public string? FacebookUrl { get; set; }
 
-        [JsonProperty("first_name"), JsonConverter(typeof(StringValueMaxLengthConverter), 40)]
+        [JsonProperty("first_name"), JsonConverter(typeof(StringValueMaxLengthConverter), FirstNameMaxLength)]
         public string? FirstName { get; set; }
 
         [JsonProperty("gender")]
@@ -38,7 +43,7 @@ namespace UserCom.Model.Users.Requests
         [JsonProperty("gravatar_url")]
         public string? GravatarUrl { get; set; }
 
-        [JsonProperty("last_name"), JsonConverter(typeof(StringValueMaxLengthConverter), 40)]
+        [JsonProperty("last_name"), JsonConverter(typeof(StringValueMaxLengthConverter), LastNameMaxLength)]
         public string? LastName { get; set; }
 
         [JsonProperty("linkedin_url")]
@@ -47,7 +52,7 @@ namespace UserCom.Model.Users.Requests
         [JsonProperty("notifications")]
         public bool? Notifications { get; set; }
 
-        [JsonProperty("phone_number"), JsonConverter(typeof(StringValueMaxLengthConverter), 64)]
+        [JsonProperty("phone_number"), JsonConverter(typeof(StringValueMaxLengthConverter), PhoneNumberMaxLength)]
         public string? PhoneNumber { get; set; }
 
         [JsonProperty("region")]

--- a/src/UserCom.Client/Model/Users/UserProductEvent.cs
+++ b/src/UserCom.Client/Model/Users/UserProductEvent.cs
@@ -19,6 +19,6 @@ namespace UserCom.Model.Users
         public string EventType { get; set; }
 
         [JsonProperty("custom_data")]
-        public Dictionary<string, object> CustomData { get; set; }
+        public Dictionary<string, object> CustomData { get; private set; }
     }
 }

--- a/src/UserCom.Client/Model/Users/UserProductEvent.cs
+++ b/src/UserCom.Client/Model/Users/UserProductEvent.cs
@@ -19,6 +19,6 @@ namespace UserCom.Model.Users
         public string EventType { get; set; }
 
         [JsonProperty("custom_data")]
-        public Dictionary<string, object> CustomData { get; private set; }
+        public Dictionary<string, object> CustomData { get; set; }
     }
 }

--- a/src/UserCom.Client/Serialization/AttributeValueConverter.cs
+++ b/src/UserCom.Client/Serialization/AttributeValueConverter.cs
@@ -37,7 +37,7 @@ namespace UserCom.Serialization
             else if (Regex.IsMatch(strValue, ArrayRegex))
             {
                 var arrayStr = strValue.Substring(1, strValue.Length - 2);
-                var arrayValue = arrayStr.Split(',').Select(s => s.Trim('"'));
+                var arrayValue = arrayStr.Split(',').Select(s => s.Trim().Trim('"'));
 
                 serializer.Serialize(writer, arrayValue);
             }

--- a/src/UserCom.Client/Serialization/AttributeValueConverter.cs
+++ b/src/UserCom.Client/Serialization/AttributeValueConverter.cs
@@ -36,8 +36,8 @@ namespace UserCom.Serialization
             }
             else if (Regex.IsMatch(strValue, ArrayRegex))
             {
-                var arrayStr = strValue.Replace("[", "").Replace("]", "");
-                var arrayValue = arrayStr.Split(',').Select(s => s.Replace("\"", ""));
+                var arrayStr = strValue.Substring(1, strValue.Length - 2);
+                var arrayValue = arrayStr.Split(',').Select(s => s.Trim('"'));
 
                 serializer.Serialize(writer, arrayValue);
             }

--- a/src/UserCom.Client/Serialization/AttributeValueConverter.cs
+++ b/src/UserCom.Client/Serialization/AttributeValueConverter.cs
@@ -9,6 +9,7 @@ namespace UserCom.Serialization
     public class AttributeValueConverter : JsonConverter
     {
         private const string ArrayRegex = @"^\[.*\]$";
+        private const string DateTimeFormat = "yyyy-MM-ddTHH:mm:ssZ";
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
@@ -52,7 +53,7 @@ namespace UserCom.Serialization
 
             if (value is DateTime dateTimeValue)
             {
-                return dateTimeValue.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+                return dateTimeValue.ToString(DateTimeFormat, CultureInfo.InvariantCulture);
             }
 
             if (value is bool boolValue)

--- a/src/UserCom.Client/Serialization/StringValueMaxLengthConverter.cs
+++ b/src/UserCom.Client/Serialization/StringValueMaxLengthConverter.cs
@@ -30,7 +30,7 @@ namespace UserCom.Serialization
 
         public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         public override bool CanConvert(Type objectType)

--- a/src/UserCom.Client/UserComAuthenticator.cs
+++ b/src/UserCom.Client/UserComAuthenticator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Net.Http;
 
 namespace UserCom
@@ -20,7 +21,7 @@ namespace UserCom
             }
 
             InnerHandler = new HttpClientHandler();
-            ServiceUri = new Uri(string.Format(apiUrl, account));
+            ServiceUri = new Uri(string.Format(CultureInfo.InvariantCulture, apiUrl, account));
         }
 
         public virtual Uri ServiceUri { get; }

--- a/src/UserCom.Client/UserComAuthenticator.cs
+++ b/src/UserCom.Client/UserComAuthenticator.cs
@@ -8,7 +8,7 @@ namespace UserCom
     {
         private const string apiUrl = "https://{0}.user.com/api/public/";
 
-        public UserComAuthenticator(string account) : base()
+        public UserComAuthenticator(string account)
         {
             if (account == null)
             {

--- a/src/UserCom.Client/UserComClient.Attributes.cs
+++ b/src/UserCom.Client/UserComClient.Attributes.cs
@@ -3,6 +3,10 @@ using System.Threading.Tasks;
 using UserCom.Model;
 using UserCom.Model.Attributes;
 
+// Explicit interface implementation is intentional: multiple interfaces on UserComClient share method names
+// (e.g. DeleteAsync, GetAllAsync) with identical signatures but different semantics. Implicit implementation
+// would cause compile-time ambiguity that cannot be resolved with public methods alone.
+#pragma warning disable S4039
 namespace UserCom
 {
     public partial class UserComClient : IUserComAttributesClient
@@ -52,3 +56,4 @@ namespace UserCom
         }
     }
 }
+#pragma warning restore S4039

--- a/src/UserCom.Client/UserComClient.Attributes.cs
+++ b/src/UserCom.Client/UserComClient.Attributes.cs
@@ -3,10 +3,7 @@ using System.Threading.Tasks;
 using UserCom.Model;
 using UserCom.Model.Attributes;
 
-// Explicit interface implementation is intentional: multiple interfaces on UserComClient share method names
-// (e.g. DeleteAsync, GetAllAsync) with identical signatures but different semantics. Implicit implementation
-// would cause compile-time ambiguity that cannot be resolved with public methods alone.
-#pragma warning disable S4039
+#pragma warning disable S4039 // Explicit implementation required: multiple interfaces share identical method signatures with different semantics
 namespace UserCom
 {
     public partial class UserComClient : IUserComAttributesClient

--- a/src/UserCom.Client/UserComClient.Crm.cs
+++ b/src/UserCom.Client/UserComClient.Crm.cs
@@ -70,7 +70,7 @@ namespace UserCom
         {
             if (request.Id == default)
             {
-                throw new ArgumentException($"{nameof(request.Id)} is missing or invalid in request");
+                throw new ArgumentException($"{nameof(request.Id)} is missing or invalid", nameof(request));
             }
 
             var result = await SendAsync<Company>(HttpMethod.Put, $"{COMPANY_RESOURCE}/{request.Id}/");

--- a/src/UserCom.Client/UserComClient.Crm.cs
+++ b/src/UserCom.Client/UserComClient.Crm.cs
@@ -6,6 +6,10 @@ using UserCom.Model;
 using UserCom.Model.CRM;
 using UserCom.Model.CRM.Requests;
 
+// Explicit interface implementation is intentional: multiple interfaces on UserComClient share method names
+// (e.g. DeleteAsync, GetAllAsync) with identical signatures but different semantics. Implicit implementation
+// would cause compile-time ambiguity that cannot be resolved with public methods alone.
+#pragma warning disable S4039
 namespace UserCom
 {
     public partial class UserComClient : IUserComCrmClient
@@ -79,3 +83,4 @@ namespace UserCom
         }
     }
 }
+#pragma warning restore S4039

--- a/src/UserCom.Client/UserComClient.Crm.cs
+++ b/src/UserCom.Client/UserComClient.Crm.cs
@@ -6,10 +6,7 @@ using UserCom.Model;
 using UserCom.Model.CRM;
 using UserCom.Model.CRM.Requests;
 
-// Explicit interface implementation is intentional: multiple interfaces on UserComClient share method names
-// (e.g. DeleteAsync, GetAllAsync) with identical signatures but different semantics. Implicit implementation
-// would cause compile-time ambiguity that cannot be resolved with public methods alone.
-#pragma warning disable S4039
+#pragma warning disable S4039 // Explicit implementation required: multiple interfaces share identical method signatures with different semantics
 namespace UserCom
 {
     public partial class UserComClient : IUserComCrmClient

--- a/src/UserCom.Client/UserComClient.CustomIdCrm.cs
+++ b/src/UserCom.Client/UserComClient.CustomIdCrm.cs
@@ -5,10 +5,7 @@ using System.Threading.Tasks;
 using UserCom.Model.CRM;
 using UserCom.Model.CRM.Requests;
 
-// Explicit interface implementation is intentional: multiple interfaces on UserComClient share method names
-// (e.g. DeleteAsync, GetAllAsync) with identical signatures but different semantics. Implicit implementation
-// would cause compile-time ambiguity that cannot be resolved with public methods alone.
-#pragma warning disable S4039
+#pragma warning disable S4039 // Explicit implementation required: multiple interfaces share identical method signatures with different semantics
 namespace UserCom
 {
     public partial class UserComClient : IUserComCustomIdCrmClient

--- a/src/UserCom.Client/UserComClient.CustomIdCrm.cs
+++ b/src/UserCom.Client/UserComClient.CustomIdCrm.cs
@@ -54,7 +54,7 @@ namespace UserCom
         {
             if (string.IsNullOrWhiteSpace(request.CompanyId))
             {
-                throw new ArgumentException($"{nameof(request.CompanyId)} is missing or invalid in request");
+                throw new ArgumentException($"{nameof(request.CompanyId)} is missing or invalid", nameof(request));
             }
 
             var result = await SendAsync<Company>(HttpMethod.Put, $"{CUSTOMIDCOMPANY_RESOURCE}/{request.CompanyId}/");

--- a/src/UserCom.Client/UserComClient.CustomIdCrm.cs
+++ b/src/UserCom.Client/UserComClient.CustomIdCrm.cs
@@ -5,6 +5,10 @@ using System.Threading.Tasks;
 using UserCom.Model.CRM;
 using UserCom.Model.CRM.Requests;
 
+// Explicit interface implementation is intentional: multiple interfaces on UserComClient share method names
+// (e.g. DeleteAsync, GetAllAsync) with identical signatures but different semantics. Implicit implementation
+// would cause compile-time ambiguity that cannot be resolved with public methods alone.
+#pragma warning disable S4039
 namespace UserCom
 {
     public partial class UserComClient : IUserComCustomIdCrmClient
@@ -63,3 +67,4 @@ namespace UserCom
         }
     }
 }
+#pragma warning restore S4039

--- a/src/UserCom.Client/UserComClient.CustomIdUsers.cs
+++ b/src/UserCom.Client/UserComClient.CustomIdUsers.cs
@@ -144,7 +144,7 @@ namespace UserCom
         {
             if(string.IsNullOrWhiteSpace(request.UserId))
             {
-                throw new ArgumentException($"{nameof(request.UserId)} is missing or invalid in request");
+                throw new ArgumentException($"{nameof(request.UserId)} is missing or invalid", nameof(request));
             }
 
             var result = await SendAsync<UpdateCustomIdUserRequest, User>(HttpMethod.Put, $"{CUSTOMIDUSER_RESOURCE}/{request.UserId}/", request);

--- a/src/UserCom.Client/UserComClient.CustomIdUsers.cs
+++ b/src/UserCom.Client/UserComClient.CustomIdUsers.cs
@@ -7,10 +7,7 @@ using UserCom.Model.Segments;
 using UserCom.Model.Users;
 using UserCom.Model.Users.Requests;
 
-// Explicit interface implementation is intentional: multiple interfaces on UserComClient share method names
-// (e.g. DeleteAsync, GetAllAsync) with identical signatures but different semantics. Implicit implementation
-// would cause compile-time ambiguity that cannot be resolved with public methods alone.
-#pragma warning disable S4039
+#pragma warning disable S4039 // Explicit implementation required: multiple interfaces share identical method signatures with different semantics
 namespace UserCom
 {
     public partial class UserComClient : IUserComCustomIdUsersClient

--- a/src/UserCom.Client/UserComClient.CustomIdUsers.cs
+++ b/src/UserCom.Client/UserComClient.CustomIdUsers.cs
@@ -7,6 +7,10 @@ using UserCom.Model.Segments;
 using UserCom.Model.Users;
 using UserCom.Model.Users.Requests;
 
+// Explicit interface implementation is intentional: multiple interfaces on UserComClient share method names
+// (e.g. DeleteAsync, GetAllAsync) with identical signatures but different semantics. Implicit implementation
+// would cause compile-time ambiguity that cannot be resolved with public methods alone.
+#pragma warning disable S4039
 namespace UserCom
 {
     public partial class UserComClient : IUserComCustomIdUsersClient
@@ -153,3 +157,4 @@ namespace UserCom
         }
     }
 }
+#pragma warning restore S4039

--- a/src/UserCom.Client/UserComClient.Lists.cs
+++ b/src/UserCom.Client/UserComClient.Lists.cs
@@ -4,10 +4,7 @@ using UserCom.Model;
 using UserCom.Model.Lists;
 using UserCom.Model.Lists.Requests;
 
-// Explicit interface implementation is intentional: multiple interfaces on UserComClient share method names
-// (e.g. DeleteAsync, GetAllAsync) with identical signatures but different semantics. Implicit implementation
-// would cause compile-time ambiguity that cannot be resolved with public methods alone.
-#pragma warning disable S4039
+#pragma warning disable S4039 // Explicit implementation required: multiple interfaces share identical method signatures with different semantics
 namespace UserCom
 {
     public partial class UserComClient : IUserComListsClient

--- a/src/UserCom.Client/UserComClient.Lists.cs
+++ b/src/UserCom.Client/UserComClient.Lists.cs
@@ -4,6 +4,10 @@ using UserCom.Model;
 using UserCom.Model.Lists;
 using UserCom.Model.Lists.Requests;
 
+// Explicit interface implementation is intentional: multiple interfaces on UserComClient share method names
+// (e.g. DeleteAsync, GetAllAsync) with identical signatures but different semantics. Implicit implementation
+// would cause compile-time ambiguity that cannot be resolved with public methods alone.
+#pragma warning disable S4039
 namespace UserCom
 {
     public partial class UserComClient : IUserComListsClient
@@ -38,3 +42,4 @@ namespace UserCom
         }
     }
 }
+#pragma warning restore S4039

--- a/src/UserCom.Client/UserComClient.Tags.cs
+++ b/src/UserCom.Client/UserComClient.Tags.cs
@@ -5,10 +5,7 @@ using UserCom.Model.CRM;
 using UserCom.Model.Tags;
 using UserCom.Model.Users;
 
-// Explicit interface implementation is intentional: multiple interfaces on UserComClient share method names
-// (e.g. DeleteAsync, GetAllAsync) with identical signatures but different semantics. Implicit implementation
-// would cause compile-time ambiguity that cannot be resolved with public methods alone.
-#pragma warning disable S4039
+#pragma warning disable S4039 // Explicit implementation required: multiple interfaces share identical method signatures with different semantics
 namespace UserCom
 {
     public partial class UserComClient : IUserComTagsClient

--- a/src/UserCom.Client/UserComClient.Tags.cs
+++ b/src/UserCom.Client/UserComClient.Tags.cs
@@ -5,6 +5,10 @@ using UserCom.Model.CRM;
 using UserCom.Model.Tags;
 using UserCom.Model.Users;
 
+// Explicit interface implementation is intentional: multiple interfaces on UserComClient share method names
+// (e.g. DeleteAsync, GetAllAsync) with identical signatures but different semantics. Implicit implementation
+// would cause compile-time ambiguity that cannot be resolved with public methods alone.
+#pragma warning disable S4039
 namespace UserCom
 {
     public partial class UserComClient : IUserComTagsClient
@@ -53,3 +57,4 @@ namespace UserCom
         }
     }
 }
+#pragma warning restore S4039

--- a/src/UserCom.Client/UserComClient.UserSegments.cs
+++ b/src/UserCom.Client/UserComClient.UserSegments.cs
@@ -4,10 +4,7 @@ using UserCom.Model;
 using UserCom.Model.Segments;
 using UserCom.Model.Users;
 
-// Explicit interface implementation is intentional: multiple interfaces on UserComClient share method names
-// (e.g. DeleteAsync, GetAllAsync) with identical signatures but different semantics. Implicit implementation
-// would cause compile-time ambiguity that cannot be resolved with public methods alone.
-#pragma warning disable S4039
+#pragma warning disable S4039 // Explicit implementation required: multiple interfaces share identical method signatures with different semantics
 namespace UserCom
 {
     public partial class UserComClient : IUserComUserSegmentClient

--- a/src/UserCom.Client/UserComClient.UserSegments.cs
+++ b/src/UserCom.Client/UserComClient.UserSegments.cs
@@ -4,6 +4,10 @@ using UserCom.Model;
 using UserCom.Model.Segments;
 using UserCom.Model.Users;
 
+// Explicit interface implementation is intentional: multiple interfaces on UserComClient share method names
+// (e.g. DeleteAsync, GetAllAsync) with identical signatures but different semantics. Implicit implementation
+// would cause compile-time ambiguity that cannot be resolved with public methods alone.
+#pragma warning disable S4039
 namespace UserCom
 {
     public partial class UserComClient : IUserComUserSegmentClient
@@ -19,3 +23,4 @@ namespace UserCom
         }
     }
 }
+#pragma warning restore S4039

--- a/src/UserCom.Client/UserComClient.Users.cs
+++ b/src/UserCom.Client/UserComClient.Users.cs
@@ -8,10 +8,7 @@ using UserCom.Model.Segments;
 using UserCom.Model.Users;
 using UserCom.Model.Users.Requests;
 
-// Explicit interface implementation is intentional: multiple interfaces on UserComClient share method names
-// (e.g. DeleteAsync, GetAllAsync) with identical signatures but different semantics. Implicit implementation
-// would cause compile-time ambiguity that cannot be resolved with public methods alone.
-#pragma warning disable S4039
+#pragma warning disable S4039 // Explicit implementation required: multiple interfaces share identical method signatures with different semantics
 namespace UserCom
 {
     public partial class UserComClient : IUserComUsersClient

--- a/src/UserCom.Client/UserComClient.Users.cs
+++ b/src/UserCom.Client/UserComClient.Users.cs
@@ -215,7 +215,7 @@ namespace UserCom
         {
             if (request.Id == default)
             {
-                throw new ArgumentException($"{nameof(request.Id)} is missing or invalid in request");
+                throw new ArgumentException($"{nameof(request.Id)} is missing or invalid", nameof(request));
             }
 
             var result = await SendAsync<UpdateUserRequest, User>(HttpMethod.Put, $"{USER_RESOURCE}/{request.Id}/", request);

--- a/src/UserCom.Client/UserComClient.Users.cs
+++ b/src/UserCom.Client/UserComClient.Users.cs
@@ -8,6 +8,10 @@ using UserCom.Model.Segments;
 using UserCom.Model.Users;
 using UserCom.Model.Users.Requests;
 
+// Explicit interface implementation is intentional: multiple interfaces on UserComClient share method names
+// (e.g. DeleteAsync, GetAllAsync) with identical signatures but different semantics. Implicit implementation
+// would cause compile-time ambiguity that cannot be resolved with public methods alone.
+#pragma warning disable S4039
 namespace UserCom
 {
     public partial class UserComClient : IUserComUsersClient
@@ -231,3 +235,4 @@ namespace UserCom
         }
     }
 }
+#pragma warning restore S4039

--- a/src/UserCom.Client/UserComClient.cs
+++ b/src/UserCom.Client/UserComClient.cs
@@ -45,11 +45,11 @@ namespace UserCom
                     }
                     catch (UserComClientException clientException) when (clientException.StatusCode == System.Net.HttpStatusCode.NotFound)
                     {
-                        return new PaginatedResult<T>() { Results = Array.Empty<T>() };
+                        return new PaginatedResult<T> { Results = Array.Empty<T>() };
                     }
                     catch (AggregateException aggregateException) when (aggregateException.InnerException is UserComClientException { StatusCode: System.Net.HttpStatusCode.NotFound })
                     {
-                        return new PaginatedResult<T>() { Results = Array.Empty<T>() };
+                        return new PaginatedResult<T> { Results = Array.Empty<T>() };
                     }
                 });
             }

--- a/src/UserCom.NetCore.Setup/ServiceCollectionExtensions.cs
+++ b/src/UserCom.NetCore.Setup/ServiceCollectionExtensions.cs
@@ -19,20 +19,17 @@ namespace UserCom.NetCore.Setup
         }
     }
 
-    public static class UserComConfiguratorExtensions
+    public class UserComConfigurator
     {
-        public static void UseToken(this UserComConfigurator configurator, string appName, string token)
+        private readonly List<Action<IServiceCollection>> _configurations = new List<Action<IServiceCollection>>();
+
+        public void UseToken(string appName, string token)
         {
-            configurator.AddConfiguration(services =>
+            AddConfiguration(services =>
             {
                 services.AddSingleton<UserComAuthenticator, TokenUserComAuthenticator>(x => new TokenUserComAuthenticator(appName, token));
             });
         }
-    }
-
-    public class UserComConfigurator
-    {
-        private readonly List<Action<IServiceCollection>> _configurations = new List<Action<IServiceCollection>>();
 
         public void AddConfiguration(Action<IServiceCollection> configurationAction)
         {

--- a/tests/Integration/ConfigHelper.cs
+++ b/tests/Integration/ConfigHelper.cs
@@ -5,7 +5,7 @@ using UserCom.Authentication;
 
 namespace Integration
 {
-    public class ConfigHelper
+    public static class ConfigHelper
     {
         public static IConfigurationRoot GetIConfigurationRoot(string outputPath)
         {

--- a/tests/UserCom/Serialization/StringValueMaxLengthConverterTestBase.cs
+++ b/tests/UserCom/Serialization/StringValueMaxLengthConverterTestBase.cs
@@ -48,7 +48,7 @@ public abstract class StringValueMaxLengthConverterTestBase<TType> where TType :
     public void Empty_object_can_be_deserialized(
         IFixture fixture)
     {
-        var objStr = "{}";
+        const string objStr = "{}";
 
         var result = JsonConvert.DeserializeObject<TType>(objStr, UserComClient.SerializerSettings);
 

--- a/tests/UserCom/Serialization/StringValueMaxLengthConverterTestBase.cs
+++ b/tests/UserCom/Serialization/StringValueMaxLengthConverterTestBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Security.Cryptography;
 using AutoFixture;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -34,7 +35,7 @@ public abstract class StringValueMaxLengthConverterTestBase<TType> where TType :
 
     [Test, CustomAutoData]
     public void Empty_object_can_be_serialized(
-        IFixture fixture, Random random)
+        IFixture fixture)
     {
         var obj = new TType();
 
@@ -45,7 +46,7 @@ public abstract class StringValueMaxLengthConverterTestBase<TType> where TType :
 
     [Test, CustomAutoData]
     public void Empty_object_can_be_deserialized(
-        IFixture fixture, Random random)
+        IFixture fixture)
     {
         var objStr = "{}";
 
@@ -56,7 +57,7 @@ public abstract class StringValueMaxLengthConverterTestBase<TType> where TType :
 
     [Test, CustomAutoData]
     public void Property_value_with_length_equal_to_MaxLength_can_be_serialized(
-        IFixture fixture, Random random)
+        IFixture fixture)
     {
         var obj = CreateObj(GenerateString(fixture, MaxLength));
 
@@ -67,7 +68,7 @@ public abstract class StringValueMaxLengthConverterTestBase<TType> where TType :
 
     [Test, CustomAutoData]
     public void Property_value_with_length_equal_to_MaxLength_can_be_deserialized(
-        IFixture fixture, Random random)
+        IFixture fixture)
     {
         var value = GenerateString(fixture, MaxLength);
         var objStr = GetJsonStr(value);
@@ -79,9 +80,9 @@ public abstract class StringValueMaxLengthConverterTestBase<TType> where TType :
 
     [Test, CustomAutoData]
     public void Property_value_with_length_less_than_MaxLength_can_be_serialized(
-        IFixture fixture, Random random)
+        IFixture fixture)
     {
-        var value = GenerateString(fixture, random.Next(1, MaxLength));
+        var value = GenerateString(fixture, RandomNumberGenerator.GetInt32(1, MaxLength));
         var obj = CreateObj(value);
         
         var result = JsonConvert.SerializeObject(obj, UserComClient.SerializerSettings);
@@ -91,9 +92,9 @@ public abstract class StringValueMaxLengthConverterTestBase<TType> where TType :
 
     [Test, CustomAutoData]
     public void Property_value_with_length_less_than_MaxLength_can_be_deserialized(
-        IFixture fixture, Random random)
+        IFixture fixture)
     {
-        var value = GenerateString(fixture, random.Next(1, MaxLength));
+        var value = GenerateString(fixture, RandomNumberGenerator.GetInt32(1, MaxLength));
         var objStr = GetJsonStr(value);
 
         var result = JsonConvert.DeserializeObject<TType>(objStr, UserComClient.SerializerSettings);
@@ -103,9 +104,9 @@ public abstract class StringValueMaxLengthConverterTestBase<TType> where TType :
 
     [Test, CustomAutoData]
     public void Property_value_with_length_more_than_MaxLength_can_be_serialized(
-        IFixture fixture, Random random)
+        IFixture fixture)
     {
-        var value = GenerateString(fixture, random.Next(MaxLength + 1, fixture.Create<Generator<int>>().First(i => i > MaxLength + 1)));
+        var value = GenerateString(fixture, RandomNumberGenerator.GetInt32(MaxLength + 1, fixture.Create<Generator<int>>().First(i => i > MaxLength + 1)));
         var obj = CreateObj(value);
 
         var result = JsonConvert.SerializeObject(obj, UserComClient.SerializerSettings);
@@ -116,9 +117,9 @@ public abstract class StringValueMaxLengthConverterTestBase<TType> where TType :
 
     [Test, CustomAutoData]
     public void Property_value_with_length_more_than_MaxLength_can_be_deserialized(
-        IFixture fixture, Random random)
+        IFixture fixture)
     {
-        var value = GenerateString(fixture, random.Next(MaxLength + 1, fixture.Create<Generator<int>>().First(i => i > MaxLength + 1)));
+        var value = GenerateString(fixture, RandomNumberGenerator.GetInt32(MaxLength + 1, fixture.Create<Generator<int>>().First(i => i > MaxLength + 1)));
         var objStr = GetJsonStr(value);
 
         var result = JsonConvert.DeserializeObject<TType>(objStr, UserComClient.SerializerSettings);

--- a/tests/UserCom/Serialization/StringValueMaxLengthConverterTestBase.cs
+++ b/tests/UserCom/Serialization/StringValueMaxLengthConverterTestBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Security.Cryptography;
+using System.Text;
 using AutoFixture;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -20,17 +21,13 @@ public abstract class StringValueMaxLengthConverterTestBase<TType> where TType :
 
     private static string GenerateString(IFixture fixture, int length)
     {
-        var s = string.Empty;
-        while (s.Length < length)
+        var sb = new StringBuilder();
+        while (sb.Length < length)
         {
-            s += fixture.Create<string>();
-        }
-        if (s.Length > length)
-        {
-            s = s[..length];
+            sb.Append(fixture.Create<string>());
         }
 
-        return s;
+        return sb.Length > length ? sb.ToString(0, length) : sb.ToString();
     }
 
     [Test, CustomAutoData]

--- a/tests/UserCom/Serialization/UpdateOrCreateUserRequestSerializationTests.cs
+++ b/tests/UserCom/Serialization/UpdateOrCreateUserRequestSerializationTests.cs
@@ -61,7 +61,7 @@ public class UpdateOrCreateUserRequestSerializationTests
     {
         protected override string GetJsonStr(string value) => $"{{\"first_name\":\"{value}\"}}";
 
-        protected override int MaxLength => 40;
+        protected override int MaxLength => UpdateOrCreateUserRequest.FirstNameMaxLength;
 
         protected override string GetValue(UpdateOrCreateUserRequest obj) => obj.FirstName;
 
@@ -73,7 +73,7 @@ public class UpdateOrCreateUserRequestSerializationTests
     {
         protected override string GetJsonStr(string value) => $"{{\"last_name\":\"{value}\"}}";
 
-        protected override int MaxLength => 40;
+        protected override int MaxLength => UpdateOrCreateUserRequest.LastNameMaxLength;
 
         protected override string GetValue(UpdateOrCreateUserRequest obj) => obj.LastName;
 
@@ -85,7 +85,7 @@ public class UpdateOrCreateUserRequestSerializationTests
     {
         protected override string GetJsonStr(string value) => $"{{\"city\":\"{value}\"}}";
 
-        protected override int MaxLength => 64;
+        protected override int MaxLength => UpdateOrCreateUserRequest.CityMaxLength;
 
         protected override string GetValue(UpdateOrCreateUserRequest obj) => obj.City;
 
@@ -97,7 +97,7 @@ public class UpdateOrCreateUserRequestSerializationTests
     {
         protected override string GetJsonStr(string value) => $"{{\"phone_number\":\"{value}\"}}";
 
-        protected override int MaxLength => 64;
+        protected override int MaxLength => UpdateOrCreateUserRequest.PhoneNumberMaxLength;
 
         protected override string GetValue(UpdateOrCreateUserRequest obj) => obj.PhoneNumber;
 

--- a/tests/UserCom/Serialization/UserSerializationTests.cs
+++ b/tests/UserCom/Serialization/UserSerializationTests.cs
@@ -13,6 +13,7 @@ namespace Tests.UserCom.Serialization
         [TestFixture]
         public class UserAttributeTests
         {
+            private const float FloatDecimalDivisor = 10f;
             [Test, CustomAutoData]
             public void String_attribute_value_can_be_deserialized(string value)
             {
@@ -113,7 +114,7 @@ namespace Tests.UserCom.Serialization
             [Test, CustomAutoData]
             public void Float_attribute_value_can_be_deserialized(float value)
             {
-                value /= 10;
+                value /= FloatDecimalDivisor;
                 var strValue = value.ToString(CultureInfo.InvariantCulture);
 
                 var userStr = $"{{\"attributes\":[{{\"value\":{strValue}}}]}}";
@@ -132,7 +133,7 @@ namespace Tests.UserCom.Serialization
             [Test, CustomAutoData]
             public void Float_attribute_value_can_be_serialized(float value)
             {
-                value /= 10;
+                value /= FloatDecimalDivisor;
                 var strValue = value.ToString(CultureInfo.InvariantCulture);
 
                 var userStr = $"{{\"attributes\":[{{\"value\":{strValue}}}]}}";

--- a/tests/UserCom/Serialization/UserSerializationTests.cs
+++ b/tests/UserCom/Serialization/UserSerializationTests.cs
@@ -48,7 +48,7 @@ namespace Tests.UserCom.Serialization
             [Test, CustomAutoData]
             public void Boolean_attribute_value_can_be_deserialized(bool value)
             {
-                var strValue = value.ToString().ToLower();
+                var strValue = value.ToString(CultureInfo.InvariantCulture).ToLowerInvariant();
 
                 var userStr = $"{{\"attributes\":[{{\"value\":{strValue}}}]}}";
 
@@ -66,7 +66,7 @@ namespace Tests.UserCom.Serialization
             [Test, CustomAutoData]
             public void Boolean_attribute_value_can_be_serialized(bool value)
             {
-                var strValue = value.ToString().ToLower();
+                var strValue = value.ToString(CultureInfo.InvariantCulture).ToLowerInvariant();
 
                 var userStr = $"{{\"attributes\":[{{\"value\":{strValue}}}]}}";
 
@@ -92,7 +92,7 @@ namespace Tests.UserCom.Serialization
                     Assert.That(result, Is.Not.Null);
                     Assert.That(result.Attributes, Is.Not.Null);
                     Assert.That(result.Attributes.Count, Is.EqualTo(1));
-                    Assert.That(result.Attributes[0].Value, Is.EqualTo(value.ToString()));
+                    Assert.That(result.Attributes[0].Value, Is.EqualTo(value.ToString(CultureInfo.InvariantCulture)));
                 });
             }
 
@@ -151,7 +151,7 @@ namespace Tests.UserCom.Serialization
             [Test, CustomAutoData]
             public void DateTime_attribute_value_can_be_deserialized(DateTime value)
             {
-                var strValue = value.ToString("yyyy-MM-ddTHH:mm:ssZ");
+                var strValue = value.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
 
                 var userStr = $"{{\"attributes\":[{{\"value\":\"{strValue}\"}}]}}";
 
@@ -169,7 +169,7 @@ namespace Tests.UserCom.Serialization
             [Test, CustomAutoData]
             public void DateTime_attribute_value_can_be_serialized(DateTime value)
             {
-                var strValue = value.ToString("yyyy-MM-ddTHH:mm:ssZ");
+                var strValue = value.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
 
                 var userStr = $"{{\"attributes\":[{{\"value\":\"{strValue}\"}}]}}";
 
@@ -186,7 +186,7 @@ namespace Tests.UserCom.Serialization
             [Test, CustomAutoData]
             public void Date_attribute_value_can_be_deserialized(DateTime value)
             {
-                var strValue = value.Date.ToString("yyyy-MM-dd");
+                var strValue = value.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 
                 var userStr = $"{{\"attributes\":[{{\"value\":\"{strValue}\"}}]}}";
 
@@ -204,7 +204,7 @@ namespace Tests.UserCom.Serialization
             [Test, CustomAutoData]
             public void Date_attribute_value_can_be_serialized(DateTime value)
             {
-                var strValue = value.Date.ToString("yyyy-MM-dd");
+                var strValue = value.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 
                 var userStr = $"{{\"attributes\":[{{\"value\":\"{strValue}\"}}]}}";
 

--- a/tests/UserCom/Serialization/UserSerializationTests.cs
+++ b/tests/UserCom/Serialization/UserSerializationTests.cs
@@ -14,6 +14,8 @@ namespace Tests.UserCom.Serialization
         public class UserAttributeTests
         {
             private const float FloatDecimalDivisor = 10f;
+            private const string DateTimeFormat = "yyyy-MM-ddTHH:mm:ssZ";
+            private const string DateFormat = "yyyy-MM-dd";
             [Test, CustomAutoData]
             public void String_attribute_value_can_be_deserialized(string value)
             {
@@ -151,7 +153,7 @@ namespace Tests.UserCom.Serialization
             [Test, CustomAutoData]
             public void DateTime_attribute_value_can_be_deserialized(DateTime value)
             {
-                var strValue = value.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+                var strValue = value.ToString(DateTimeFormat, CultureInfo.InvariantCulture);
 
                 var userStr = $"{{\"attributes\":[{{\"value\":\"{strValue}\"}}]}}";
 
@@ -169,7 +171,7 @@ namespace Tests.UserCom.Serialization
             [Test, CustomAutoData]
             public void DateTime_attribute_value_can_be_serialized(DateTime value)
             {
-                var strValue = value.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+                var strValue = value.ToString(DateTimeFormat, CultureInfo.InvariantCulture);
 
                 var userStr = $"{{\"attributes\":[{{\"value\":\"{strValue}\"}}]}}";
 
@@ -186,7 +188,7 @@ namespace Tests.UserCom.Serialization
             [Test, CustomAutoData]
             public void Date_attribute_value_can_be_deserialized(DateTime value)
             {
-                var strValue = value.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+                var strValue = value.Date.ToString(DateFormat, CultureInfo.InvariantCulture);
 
                 var userStr = $"{{\"attributes\":[{{\"value\":\"{strValue}\"}}]}}";
 
@@ -204,7 +206,7 @@ namespace Tests.UserCom.Serialization
             [Test, CustomAutoData]
             public void Date_attribute_value_can_be_serialized(DateTime value)
             {
-                var strValue = value.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+                var strValue = value.Date.ToString(DateFormat, CultureInfo.InvariantCulture);
 
                 var userStr = $"{{\"attributes\":[{{\"value\":\"{strValue}\"}}]}}";
 

--- a/tests/UserCom/UserComClientListTests.cs
+++ b/tests/UserCom/UserComClientListTests.cs
@@ -19,6 +19,7 @@ namespace Tests.UserCom
         [TestFixture]
         public class PaginatedResult_Next
         {
+            private const int ExpectedSendAsyncCallCount = 2;
             [Test, CustomAutoData]
             public async Task PaginatedResult_Next_does_not_throw_if_nextUrl_from_userCom_throws_404(
                 Mock<HttpMessageHandler> handler,
@@ -86,7 +87,7 @@ namespace Tests.UserCom
 
                 handler.Protected().Verify(
                     "SendAsync",
-                    Times.Exactly(2),
+                    Times.Exactly(ExpectedSendAsyncCallCount),
                     ItExpr.IsAny<HttpRequestMessage>(),
                     ItExpr.IsAny<CancellationToken>());
             }

--- a/tests/UserCom/UserComClientListTests.cs
+++ b/tests/UserCom/UserComClientListTests.cs
@@ -25,8 +25,8 @@ namespace Tests.UserCom
                 Mock<HttpMessageHandler> handler,
                 string account)
             {
-                var listAllUrl = $"{ListResource}/";
-                var nextUrl = $"{ListResource}?cursor=101";
+                const string listAllUrl = ListResource + "/";
+                const string nextUrl = ListResource + "?cursor=101";
                 
                 // Initial request in GetAllAsync
                 handler.Protected()
@@ -97,8 +97,8 @@ namespace Tests.UserCom
                 Mock<HttpMessageHandler> handler,
                 string account)
             {
-                var listAllUrl = $"{ListResource}/";
-                var nextUrl = $"{ListResource}?cursor=101";
+                const string listAllUrl = ListResource + "/";
+                const string nextUrl = ListResource + "?cursor=101";
 
                 // Initial request in GetAllAsync
                 handler.Protected()

--- a/tests/UserCom/UserComClientListTests.cs
+++ b/tests/UserCom/UserComClientListTests.cs
@@ -17,12 +17,12 @@ namespace Tests.UserCom
         private const string ListResource = "/api/public/lists";
 
         [TestFixture]
-        public class PaginatedResult_Next
+        public class PaginatedResultNext
         {
             private const string SendAsyncMethodName = "SendAsync";
             private const int ExpectedSendAsyncCallCount = 2;
             [Test, CustomAutoData]
-            public async Task PaginatedResult_Next_does_not_throw_if_nextUrl_from_userCom_throws_404(
+            public async Task PaginatedResultNext_does_not_throw_if_nextUrl_from_userCom_throws_404(
                 Mock<HttpMessageHandler> handler,
                 string account)
             {
@@ -94,7 +94,7 @@ namespace Tests.UserCom
             }
 
             [Test, CustomAutoData]
-            public async Task PaginatedResult_Next_returns_empty_paginatedResult_if_nextUrl_from_userCom_throws_404(
+            public async Task PaginatedResultNext_returns_empty_paginatedResult_if_nextUrl_from_userCom_throws_404(
                 Mock<HttpMessageHandler> handler,
                 string account)
             {

--- a/tests/UserCom/UserComClientListTests.cs
+++ b/tests/UserCom/UserComClientListTests.cs
@@ -19,6 +19,7 @@ namespace Tests.UserCom
         [TestFixture]
         public class PaginatedResult_Next
         {
+            private const string SendAsyncMethodName = "SendAsync";
             private const int ExpectedSendAsyncCallCount = 2;
             [Test, CustomAutoData]
             public async Task PaginatedResult_Next_does_not_throw_if_nextUrl_from_userCom_throws_404(
@@ -31,7 +32,7 @@ namespace Tests.UserCom
                 // Initial request in GetAllAsync
                 handler.Protected()
                     .Setup<Task<HttpResponseMessage>>(
-                        "SendAsync",
+                        SendAsyncMethodName,
                         ItExpr.Is<HttpRequestMessage>(m => m.RequestUri.PathAndQuery.Equals(listAllUrl)),
                         ItExpr.IsAny<CancellationToken>())
                     .ReturnsAsync(() => new HttpResponseMessage
@@ -49,7 +50,7 @@ namespace Tests.UserCom
                 // "Next" request
                 handler.Protected()
                     .Setup<Task<HttpResponseMessage>>(
-                        "SendAsync",
+                        SendAsyncMethodName,
                         ItExpr.Is<HttpRequestMessage>(m => m.RequestUri.PathAndQuery.Equals(nextUrl)),
                         ItExpr.IsAny<CancellationToken>())
                     .ReturnsAsync(() => new HttpResponseMessage
@@ -74,19 +75,19 @@ namespace Tests.UserCom
                 });
 
                 handler.Protected().Verify(
-                    "SendAsync",
+                    SendAsyncMethodName,
                     Times.Once(),
                     ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get && req.RequestUri.PathAndQuery.Equals(listAllUrl)),
                     ItExpr.IsAny<CancellationToken>());
 
                 handler.Protected().Verify(
-                   "SendAsync",
+                   SendAsyncMethodName,
                    Times.Once(),
                    ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get && req.RequestUri.PathAndQuery.Equals(nextUrl)),
                    ItExpr.IsAny<CancellationToken>());
 
                 handler.Protected().Verify(
-                    "SendAsync",
+                    SendAsyncMethodName,
                     Times.Exactly(ExpectedSendAsyncCallCount),
                     ItExpr.IsAny<HttpRequestMessage>(),
                     ItExpr.IsAny<CancellationToken>());
@@ -103,7 +104,7 @@ namespace Tests.UserCom
                 // Initial request in GetAllAsync
                 handler.Protected()
                     .Setup<Task<HttpResponseMessage>>(
-                        "SendAsync",
+                        SendAsyncMethodName,
                         ItExpr.Is<HttpRequestMessage>(m => m.RequestUri.PathAndQuery.Equals(listAllUrl)),
                         ItExpr.IsAny<CancellationToken>())
                     .ReturnsAsync(() => new HttpResponseMessage
@@ -121,7 +122,7 @@ namespace Tests.UserCom
                 // "Next" request
                 handler.Protected()
                     .Setup<Task<HttpResponseMessage>>(
-                        "SendAsync",
+                        SendAsyncMethodName,
                         ItExpr.Is<HttpRequestMessage>(m => m.RequestUri.PathAndQuery.Equals(nextUrl)),
                         ItExpr.IsAny<CancellationToken>())
                     .ReturnsAsync(() => new HttpResponseMessage

--- a/tests/UserCom/UserComClientListTests.cs
+++ b/tests/UserCom/UserComClientListTests.cs
@@ -70,7 +70,7 @@ namespace Tests.UserCom
 
                 Assert.DoesNotThrow(() =>
                 {
-                    var next = initial.Next.Value;
+                    _ = initial.Next.Value;
                 });
 
                 handler.Protected().Verify(

--- a/tests/UserCom/UserComClientListTests.cs
+++ b/tests/UserCom/UserComClientListTests.cs
@@ -21,13 +21,14 @@ namespace Tests.UserCom
         {
             private const string SendAsyncMethodName = "SendAsync";
             private const int ExpectedSendAsyncCallCount = 2;
+            private const string NextPageCursor = "?cursor=101";
             [Test, CustomAutoData]
             public async Task PaginatedResultNext_does_not_throw_if_nextUrl_from_userCom_throws_404(
                 Mock<HttpMessageHandler> handler,
                 string account)
             {
                 const string listAllUrl = ListResource + "/";
-                const string nextUrl = ListResource + "?cursor=101";
+                const string nextUrl = ListResource + NextPageCursor;
                 
                 // Initial request in GetAllAsync
                 handler.Protected()
@@ -99,7 +100,7 @@ namespace Tests.UserCom
                 string account)
             {
                 const string listAllUrl = ListResource + "/";
-                const string nextUrl = ListResource + "?cursor=101";
+                const string nextUrl = ListResource + NextPageCursor;
 
                 // Initial request in GetAllAsync
                 handler.Protected()


### PR DESCRIPTION
 Addresses 22 Codacy/SonarQube findings across the SDK and test projects.
  All changes are non-breaking. Build and tests pass after each fix.

  Security / correctness
  - S2302: Pass nameof(request) as paramName to all four ArgumentException guard clauses in UpdateAsync methods
  - WeakRNG: Replace System.Random with RandomNumberGenerator.GetInt32 in serialization tests
  - S4056: Add CultureInfo.InvariantCulture to string.Format, Convert.ChangeType, bool/int/DateTime.ToString calls
  - S4058: Replace culture-sensitive string.Replace calls with Substring/Trim in AttributeValueConverter (netstandard2.0 compatible)

  Code quality
  - S1541: Replace 10-arm switch in FilterExtensions.ToQueryParam with a static dictionary lookup to reduce cyclomatic complexity
  - S4226: Move UseToken extension method into UserComConfigurator as a regular method
  - S1643: Replace string concatenation in loop with StringBuilder in StringValueMaxLengthConverterTestBase
  - S4027: Add missing standard constructors (default, message, message+inner) to UserComClientException
  - S1118: Make ConfigHelper static (all methods were already static)
  - S4004: Make UserProductEvent.CustomData setter private
  - S3717: Replace NotImplementedException with NotSupportedException in StringValueMaxLengthConverter.ReadJson stub
  - S4039: Suppress with #pragma warning disable in all 8 partial UserComClient files — explicit interface implementation is required because multiple
  interfaces share identical method signatures (e.g. DeleteAsync, GetAllAsync) with different semantics

  Code style / cleanup
  - S109: Extract magic numbers to named constants in UpdateOrCreateUserRequest (field max lengths) and tests
  - S6585: Extract hardcoded DateTime/Date format specifiers to constants in AttributeValueConverter and UserSerializationTests
  - S3353: Add const modifier to local string variables (listAllUrl, nextUrl, objStr)
  - S3235: Remove redundant parentheses from object initializers in UserComClient
  - S3253: Remove redundant base() call in UserComAuthenticator constructor
  - S1192: Extract repeated "SendAsync" string literal to a named constant in UserComClientListTests
  - S1481: Remove unused local variable in UserComClientListTests
  - S1449: Fix bool.ToString().ToLower() → ToString(CultureInfo.InvariantCulture).ToLowerInvariant() (resolved as part of S4056)
  - S101: Rename test class PaginatedResult_Next to PaginatedResultNext (PascalCase)